### PR TITLE
Use File.exist? over File.exists?

### DIFF
--- a/lib/logging/rails/railtie.rb
+++ b/lib/logging/rails/railtie.rb
@@ -15,7 +15,7 @@ module Logging::Rails
 
     initializer 'logging.configure', :before => 'initialize_logger' do |app|
       file = ::Rails.root.join('config/logging.rb')
-      load file if File.exists? file
+      load file if File.exist? file
       ::Logging::Rails.configuration.call(app.config) if ::Logging::Rails.configuration
     end
 


### PR DESCRIPTION
This is a tiny change to ensure that logging-rails works with Ruby 3.2.0. `File.exists?` has been deprecated in Ruby 3.2.0. This patch just uses the `File.exist?` method.